### PR TITLE
[MOV-FIX] Kakao Login Context 문제 수정

### DIFF
--- a/MoveLog/data/src/main/java/com/ilgusu/data/di/ServiceModule.kt
+++ b/MoveLog/data/src/main/java/com/ilgusu/data/di/ServiceModule.kt
@@ -1,26 +1,16 @@
 package com.ilgusu.data.di
 
-import android.content.Context
-import com.ilgusu.data.service.KakaoAuthService
 import com.ilgusu.data.service.RecordService
 import com.ilgusu.data.service.auth.AuthService
-import com.kakao.sdk.user.UserApiClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
 internal class ServiceModule {
-
-    @Provides
-    fun providesKakaoAuthService(
-        @ApplicationContext context: Context,
-        client: UserApiClient = UserApiClient.instance
-    ): KakaoAuthService = KakaoAuthService(context, client)
 
     @Provides
     fun providesAuthService(

--- a/MoveLog/data/src/main/java/com/ilgusu/data/repository/AuthRepositoryImpl.kt
+++ b/MoveLog/data/src/main/java/com/ilgusu/data/repository/AuthRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.ilgusu.data.repository
 
+import android.app.Activity
+import android.content.Context
 import com.ilgusu.data.datasource.remote.AuthRemoteDataSource
 import com.ilgusu.data.service.KakaoAuthService
 import com.ilgusu.domain.model.AuthProvider
@@ -14,11 +16,11 @@ class AuthRepositoryImpl @Inject constructor(
     private val tokenRepository: TokenRepository
 ) : AuthRepository {
 
-    override suspend fun socialLogin(provider: AuthProvider): Result<String> {
+    override suspend fun socialLogin(context: Any, provider: AuthProvider): Result<String> {
         return try {
             when (provider) {
                 AuthProvider.KAKAO -> {
-                    val idToken = kakaoAuthService.signInWithKakao()
+                    val idToken = kakaoAuthService.signInWithKakao(context as Activity)
                     Result.success(idToken)
                 }
                 AuthProvider.GOOGLE -> {

--- a/MoveLog/domain/src/main/java/com/ilgusu/domain/repository/AuthRepository.kt
+++ b/MoveLog/domain/src/main/java/com/ilgusu/domain/repository/AuthRepository.kt
@@ -4,7 +4,7 @@ import com.ilgusu.domain.model.AuthProvider
 
 interface AuthRepository {
 
-    suspend fun socialLogin(provider: AuthProvider): Result<String>
+    suspend fun socialLogin(context: Any, provider: AuthProvider): Result<String>
 
     suspend fun socialSignOut(provider: AuthProvider): Result<Boolean>
 

--- a/MoveLog/domain/src/main/java/com/ilgusu/domain/usecase/auth/SocialLoginUseCase.kt
+++ b/MoveLog/domain/src/main/java/com/ilgusu/domain/usecase/auth/SocialLoginUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class SocialLoginUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(provider: AuthProvider): Result<String> {
-        return authRepository.socialLogin(provider)
+    suspend operator fun invoke(context: Any, provider: AuthProvider): Result<String> {
+        return authRepository.socialLogin(context, provider)
     }
 }

--- a/MoveLog/presentation/src/main/java/com/ilgusu/presentation/view/signIn/SignInFragment.kt
+++ b/MoveLog/presentation/src/main/java/com/ilgusu/presentation/view/signIn/SignInFragment.kt
@@ -38,7 +38,7 @@ class SignInFragment: BaseFragment<FragmentSignInBinding>() {
     }
 
     private fun doLogin(provider: AuthProvider) {
-        viewModel.login(provider)
+        viewModel.login(requireActivity(), provider)
     }
 
     override fun setObserver() {

--- a/MoveLog/presentation/src/main/java/com/ilgusu/presentation/view/signIn/SignInViewModel.kt
+++ b/MoveLog/presentation/src/main/java/com/ilgusu/presentation/view/signIn/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package com.ilgusu.presentation.view.signIn
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -40,11 +41,16 @@ class SignInViewModel @Inject constructor(
         }
     }
 
-    fun login(provider: AuthProvider) {
+    fun login(context: Context, provider: AuthProvider) {
+        if(provider == AuthProvider.GOOGLE) {
+            _loginState.value = UiState.Error("준비중 입니다")
+            return
+        }
+
         _loginState.value = UiState.Loading
         viewModelScope.launch {
             try {
-                socialLoginUseCase.invoke(provider)
+                socialLoginUseCase.invoke(context, provider)
                     .onSuccess { idToken ->
                         LoggerUtil.d("${provider.name} 로그인 성공: $idToken")
                         serverLogin(idToken, provider)


### PR DESCRIPTION
### 수정 사항 1

Application Context로 의존성 주입 받아 사용하던 구조로 인해 카카오톡으로 로그인 시 오류 발생.

```
Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag.
```
따라서 매개변수를 직접 입력 받아 Activity Context를 사용하도록 수정함.

<br>

### 수정 사항 2

카카오톡 설치 여부를 확인하여 분기처리를 했을 때, 카카오톡이 설치가 되어있지만, 로그인이 되어있지 않은 경우
계정으로 로그인 플로우로 넘어가지 않기 때문에 문제가 있음.

카카오톡으로 로그인에서 문제가 발생할 시 카카오계정으로 로그인 플로우로 넘어가도록 수정함

<br>

### 수정 사항 3

구글 로그인 클릭 이벤트 -> `준비중` 처리
